### PR TITLE
feat: add debugging to show more details about errors

### DIFF
--- a/config/SecretSync.php
+++ b/config/SecretSync.php
@@ -34,6 +34,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Debug Mode for Secret Sync
+    |--------------------------------------------------------------------------
+    |
+    | This option enables debug output when running secretsync via the CLI.
+    | It can be helpful for displaying detailed error messages or additional
+    | information during development or troubleshooting.
+    |
+    */
+
+    'debug' => env('SECRETSYNC_DEBUG', false),
+
+    /*
+    |--------------------------------------------------------------------------
     | Infisical Provider Configuration
     |--------------------------------------------------------------------------
     |
@@ -46,7 +59,7 @@ return [
     'infisical' => [
         'token' => env('INFISICAL_TOKEN', 'token'),
         'api_endpoint' => env('INFISICAL_API_ENDPOINT', 'endpoint'),
-        'env' => env('INFISICAL_ENV', 'enviroment'),
+        'env' => env('INFISICAL_ENV', 'environment'),
         'workspace_id' => env('INFISICAL_WORK_ID', 'workId'),
     ],
 ];

--- a/src/Interfaces/SecretProviderInterface.php
+++ b/src/Interfaces/SecretProviderInterface.php
@@ -2,8 +2,9 @@
 
 namespace UmarJimoh\SecretSync\Interfaces;
 
-interface SecretProviderInterface 
+interface SecretProviderInterface
 {
     public function getSecrets(): array;
     public function name(): string;
+    public function checkResponseForErrors(array $response): array|Bool;
 }

--- a/src/Providers/InfisicalProvider.php
+++ b/src/Providers/InfisicalProvider.php
@@ -11,6 +11,7 @@ class InfisicalProvider implements SecretProviderInterface
     public function getSecrets(): array
     {
         $config = config('secretsync.infisical');
+        $debug = config('secretsync.debug');
 
         try {
             $response = Http::withToken($config['token'])->get($config['api_endpoint'], [
@@ -18,8 +19,10 @@ class InfisicalProvider implements SecretProviderInterface
                 'workspaceId' => $config['workspace_id'],
             ]);
 
-            if (!$response->successful()) {
-                throw new Exception();
+            $responseBody = json_decode($response->body(), true);
+
+            if ($debug && $error = $this->checkResponseForErrors($responseBody)) {
+                return ['debug' => $error];
             }
 
             $secrets = [];
@@ -29,8 +32,29 @@ class InfisicalProvider implements SecretProviderInterface
 
             return $secrets;
         } catch (Exception $e) {
+            if ($debug) {
+                return ['debug' => print_r($e->getMessage(), true)];
+            }
             return [];
         }
+    }
+
+    public function checkResponseForErrors(array $response): array|Bool
+    {
+        if (isset($response['statusCode']) && $response['statusCode'] >= 400) {
+            return [
+                'message' => $response['message'] ?? 'Unknown error occurred.',
+                'details' => 'Request ID: ' . ($response['reqId'] ?? 'N/A') . ', Error: ' . ($response['error'] ?? 'N/A'),
+            ];
+        }
+
+        if (empty($response['secrets'])) {
+            return [
+                'message' => $response['message'] ?? 'The specified environment slug is either incorrect or exists but contains no secrets on Infisical. Please double-check the "INFISICAL_ENV" value and ensure it is not empty.',
+                'details' => 'No additional error info provided.',
+            ];
+        }
+        return false;
     }
 
     public function name(): string

--- a/src/SecretSync.php
+++ b/src/SecretSync.php
@@ -97,6 +97,10 @@ class SecretSync
     {
         $secrets = $provider->getSecrets();
 
+        if (isset($secrets['debug'])) {
+            return ['error' => $secrets['debug']];
+        }
+
         if (empty($secrets)) {
             return ['error' => "Failed to fetch secret from the provider: " . $provider->name()];
         }


### PR DESCRIPTION
## This pull request introduces the following changes:

### What's Included

####  1. Add `--debug` flag to `php artisan secretsync`
- Introduced a `--debug` flag to the `secretsync` Artisan command. When enabled, it displays more detailed error information to help with troubleshooting.